### PR TITLE
Use `onewireio.OneWire`

### DIFF
--- a/adafruit_onewire/bus.py
+++ b/adafruit_onewire/bus.py
@@ -14,7 +14,7 @@ Provide access to a 1-Wire bus.
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_OneWire.git"
 
-import busio
+import onewireio
 from micropython import const
 
 try:

--- a/adafruit_onewire/bus.py
+++ b/adafruit_onewire/bus.py
@@ -65,7 +65,7 @@ class OneWireBus:
 
     def __init__(self, pin: Pin) -> None:
         # pylint: disable=no-member
-        self._ow = busio.OneWire(pin)
+        self._ow = onewireio.OneWire(pin)
         self._readbit = self._ow.read_bit
         self._writebit = self._ow.write_bit
         self._maximum_devices = _MAX_DEV


### PR DESCRIPTION
We are moving `OneWire` to its own module.

In CircuitPython 6.x.x, `OneWire` is available  as `busio.OneWire`.
In CircuitPython 7.x.x, `OneWire` is available as `busio.OneWire` _and_ as `onewireio.OneWire`.
In CircuitPython 8.x.x, `OneWire` will be available  only as `onewireio.OneWire`.

Have this library catch up to `onewireio.OneWire`. This will be a major version change.